### PR TITLE
switching to safe_load. Fixes #100

### DIFF
--- a/locopy/utility.py
+++ b/locopy/utility.py
@@ -238,9 +238,9 @@ def read_config_yaml(config_yaml):
     try:
         if isinstance(config_yaml, str):
             with open(config_yaml) as config:
-                locopy_yaml = yaml.load(config)
+                locopy_yaml = yaml.safe_load(config)
         else:
-            locopy_yaml = yaml.load(config_yaml)
+            locopy_yaml = yaml.safe_load(config_yaml)
     except Exception as e:
         logger.error("Error reading yaml. err: %s", e)
         raise CredentialsError("Error reading yaml.")


### PR DESCRIPTION
This should fix the YAML issue and not cause any adverse affects. Since we are only using the pyyaml for reading in some small db configs the safe load should be more than enough and not interfere with anything else.

Closes #100 