### PR TITLE
fixing repo name change to locopy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/capitalone/Data-Load-and-Copy-using-Python.svg?branch=master
-    :target: https://travis-ci.org/capitalone/Data-Load-and-Copy-using-Python
+.. image:: https://travis-ci.org/capitalone/locopy.svg?branch=master
+    :target: https://travis-ci.org/capitalone/locopy
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 
@@ -148,7 +148,7 @@ for more information, but you can:
 Advanced Usage
 --------------
 
-See the `docs <https://capitalone.github.io/Data-Load-and-Copy-using-Python/>`_ for
+See the `docs <https://capitalone.github.io/locopy/>`_ for
 more detailed usage instructions and examples including Snowflake.
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@
    :caption: API Reference
 
    API Reference <api/modules>
-   Github Repo <https://github.com/capitalone/Data-Load-and-Copy-using-Python>
+   Github Repo <https://github.com/capitalone/locopy>
 
 
 Indices and tables

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     version=__version__,
     description="Loading/Unloading to Amazon Redshift using Python",
     long_description=LONG_DESCRIPTION,
-    url="https://github.com/capitalone/Data-Load-and-Copy-using-Python",
+    url="https://github.com/capitalone/locopy",
     author="Faisal Dosani",
     author_email="faisal.dosani@capitalone.com",
     license="Apache Software License",


### PR DESCRIPTION
The name change caused some broken links. This should fix them.