### PR TITLE
Update edgetest action to 1.3

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -19,7 +19,7 @@ jobs:
           cp tests/data/.locopyrc ~/.locopyrc
           cp tests/data/.locopy-sfrc ~/.locopy-sfrc
       - id: run-edgetest
-        uses: fdosani/run-edgetest-action@v1.0
+        uses: fdosani/run-edgetest-action@v1.3
         with:
           edgetest-flags: '-c pyproject.toml --export'
           base-branch: 'develop'


### PR DESCRIPTION
- Fixes #222 
- bumps up the action version which should support `pyproject.toml` now.