### PR TITLE
fix find_column_type utility method

### DIFF
--- a/locopy/snowflake.py
+++ b/locopy/snowflake.py
@@ -85,7 +85,7 @@ UNLOAD_FORMAT_OPTIONS = {
 
 
 def combine_options(options=None):
-    """ Returns the ``copy_options`` or ``format_options`` attribute with spaces in between and as
+    """Returns the ``copy_options`` or ``format_options`` attribute with spaces in between and as
     a string. If options is ``None`` then return an empty string.
 
     Parameters
@@ -170,11 +170,15 @@ class Snowflake(S3, Database):
         Issue initializing S3 session
     """
 
-    def __init__(self, profile=None, kms_key=None, dbapi=None, config_yaml=None, **kwargs):
+    def __init__(
+        self, profile=None, kms_key=None, dbapi=None, config_yaml=None, **kwargs
+    ):
         try:
             S3.__init__(self, profile, kms_key)
         except S3CredentialsError:
-            logger.warning("S3 credentials were not found. S3 functionality is disabled")
+            logger.warning(
+                "S3 credentials were not found. S3 functionality is disabled"
+            )
             logger.warning("Only internal stages are available")
         Database.__init__(self, dbapi, config_yaml, **kwargs)
 
@@ -196,7 +200,9 @@ class Snowflake(S3, Database):
         if self.connection.get("schema") is not None:
             self.execute("USE SCHEMA {0}".format(self.connection["schema"]))
 
-    def upload_to_internal(self, local, stage, parallel=4, auto_compress=True, overwrite=True):
+    def upload_to_internal(
+        self, local, stage, parallel=4, auto_compress=True, overwrite=True
+    ):
         """
         Upload file(s) to a internal stage via the ``PUT`` command.
 
@@ -249,9 +255,13 @@ class Snowflake(S3, Database):
         if local is None:
             local = os.getcwd()
         local_uri = PurePath(local).as_posix()
-        self.execute("GET {0} 'file://{1}' PARALLEL={2}".format(stage, local_uri, parallel))
+        self.execute(
+            "GET {0} 'file://{1}' PARALLEL={2}".format(stage, local_uri, parallel)
+        )
 
-    def copy(self, table_name, stage, file_type="csv", format_options=None, copy_options=None):
+    def copy(
+        self, table_name, stage, file_type="csv", format_options=None, copy_options=None
+    ):
         """Executes the ``COPY INTO <table>`` command to load CSV files from a stage into
         a Snowflake table. If ``file_type == csv`` and ``format_options == None``, ``format_options``
         will default to: ``["FIELD_DELIMITER='|'", "SKIP_HEADER=0"]``
@@ -286,7 +296,9 @@ class Snowflake(S3, Database):
 
         if file_type not in COPY_FORMAT_OPTIONS:
             raise ValueError(
-                "Invalid file_type. Must be one of {0}".format(list(COPY_FORMAT_OPTIONS.keys()))
+                "Invalid file_type. Must be one of {0}".format(
+                    list(COPY_FORMAT_OPTIONS.keys())
+                )
             )
 
         if format_options is None and file_type == "csv":
@@ -294,7 +306,9 @@ class Snowflake(S3, Database):
 
         format_options_text = combine_options(format_options)
         copy_options_text = combine_options(copy_options)
-        base_copy_string = "COPY INTO {0} FROM '{1}' " "FILE_FORMAT = (TYPE='{2}' {3}) {4}"
+        base_copy_string = (
+            "COPY INTO {0} FROM '{1}' " "FILE_FORMAT = (TYPE='{2}' {3}) {4}"
+        )
         try:
             sql = base_copy_string.format(
                 table_name, stage, file_type, format_options_text, copy_options_text
@@ -350,7 +364,9 @@ class Snowflake(S3, Database):
 
         if file_type not in COPY_FORMAT_OPTIONS:
             raise ValueError(
-                "Invalid file_type. Must be one of {0}".format(list(UNLOAD_FORMAT_OPTIONS.keys()))
+                "Invalid file_type. Must be one of {0}".format(
+                    list(UNLOAD_FORMAT_OPTIONS.keys())
+                )
             )
 
         if format_options is None and file_type == "csv":
@@ -364,7 +380,12 @@ class Snowflake(S3, Database):
 
         try:
             sql = base_unload_string.format(
-                stage, table_name, file_type, format_options_text, header, copy_options_text
+                stage,
+                table_name,
+                file_type,
+                format_options_text,
+                header,
+                copy_options_text,
             )
             self.execute(sql, commit=True)
         except Exception as e:
@@ -422,7 +443,7 @@ class Snowflake(S3, Database):
         if create:
             if not metadata:
                 logger.info("Metadata is missing. Generating metadata ...")
-                metadata = find_column_type(dataframe)
+                metadata = find_column_type(dataframe, "snowflake")
                 logger.info("Metadata is complete. Creating new table ...")
 
             create_join = (

--- a/locopy/utility.py
+++ b/locopy/utility.py
@@ -27,13 +27,8 @@ from itertools import cycle
 
 import yaml
 
-from .errors import (
-    CompressionError,
-    CredentialsError,
-    LocopyConcatError,
-    LocopyIgnoreHeaderError,
-    LocopySplitError,
-)
+from .errors import (CompressionError, CredentialsError, LocopyConcatError,
+                     LocopyIgnoreHeaderError, LocopySplitError)
 from .logger import INFO, get_logger
 
 logger = get_logger(__name__, INFO)
@@ -250,7 +245,7 @@ def read_config_yaml(config_yaml):
 
 
 # make it more granular, eg. include length
-def find_column_type(dataframe):
+def find_column_type(dataframe, warehouse_type: str):
     """
     Find data type of each column from the dataframe.
 
@@ -271,6 +266,9 @@ def find_column_type(dataframe):
     ----------
     dataframe : Pandas dataframe
 
+    warehouse_type: str
+        Required to properly determine format of uploaded data, either "snowflake" or "redshift".
+
     Returns
     -------
     dict
@@ -284,10 +282,16 @@ def find_column_type(dataframe):
     def validate_date_object(column):
         try:
             pd.to_datetime(column)
-            if re.search(r"\d+:\d+:\d+", column.sample(1).to_string(index=False)):
+            sample_data = column.sample(1).to_string(index=False)
+            if re.search(r"\d+:\d+:\d+", sample_data):
                 return "timestamp"
-            else:
+            elif warehouse_type == "redshift" or re.search(
+                r"(\d{4}-\d{2}-\d{2})|(\d{2}-\d{2}-\d{4})|(\d{2}/\d{2}/\d{4})",
+                sample_data,
+            ):
                 return "date"
+            else:
+                return "varchar"
         except (ValueError, TypeError):
             return None
 
@@ -297,6 +301,11 @@ def find_column_type(dataframe):
             return "float"
         except (ValueError, TypeError):
             return None
+
+    if warehouse_type.lower() not in ["snowflake", "redshift"]:
+        raise ValueError(
+            'warehouse_type argument must be either "snowflake" or "redshift"'
+        )
 
     column_type = []
     for column in dataframe.columns:

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -24,29 +24,20 @@ import os
 import sys
 from io import StringIO
 from itertools import cycle
-from unittest import mock
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 import locopy.utility as util
-from locopy.errors import (
-    CompressionError,
-    CredentialsError,
-    LocopyConcatError,
-    LocopyIgnoreHeaderError,
-    LocopySplitError,
-)
-from locopy.utility import (
-    compress_file,
-    compress_file_list,
-    concatenate_files,
-    find_column_type,
-    get_ignoreheader_number,
-    split_file,
-)
+from locopy.errors import (CompressionError, CredentialsError,
+                           LocopyConcatError, LocopyIgnoreHeaderError,
+                           LocopySplitError)
+from locopy.utility import (compress_file, compress_file_list,
+                            concatenate_files, find_column_type,
+                            get_ignoreheader_number, split_file)
 
-GOOD_CONFIG_YAML = u"""host: my.redshift.cluster.com
+GOOD_CONFIG_YAML = """host: my.redshift.cluster.com
 port: 1234
 database: db
 user: userid
@@ -81,7 +72,9 @@ def test_compress_file(mock_shutil, mock_gzip_open, mock_open):
     compress_file("input", "output")
     mock_open.assert_called_with("input", "rb")
     mock_gzip_open.assert_called_with("output", "wb")
-    mock_shutil.assert_called_with(mock_open().__enter__(), mock_gzip_open().__enter__())
+    mock_shutil.assert_called_with(
+        mock_open().__enter__(), mock_gzip_open().__enter__()
+    )
 
 
 @mock.patch("locopy.utility.open")
@@ -110,7 +103,9 @@ def test_compress_file_list(mock_shutil, mock_gzip_open, mock_open, mock_remove)
 @mock.patch("locopy.utility.open")
 @mock.patch("locopy.utility.gzip.open")
 @mock.patch("locopy.utility.shutil.copyfileobj")
-def test_compress_file_list_exception(mock_shutil, mock_gzip_open, mock_open, mock_remove):
+def test_compress_file_list_exception(
+    mock_shutil, mock_gzip_open, mock_open, mock_remove
+):
     mock_shutil.side_effect = Exception("SomeException")
     with pytest.raises(CompressionError):
         compress_file_list(["input1", "input2"])
@@ -123,7 +118,10 @@ def test_split_file():
     splits = split_file(input_file, output_file)
     assert splits == [input_file]
 
-    expected = ["tests/data/mock_output_file.txt.0", "tests/data/mock_output_file.txt.1"]
+    expected = [
+        "tests/data/mock_output_file.txt.0",
+        "tests/data/mock_output_file.txt.1",
+    ]
     splits = split_file(input_file, output_file, 2)
     assert splits == expected
     assert compare_file_contents(input_file, expected)
@@ -213,18 +211,18 @@ def test_split_file_exception():
         split_file(input_file, output_file, "Test")
 
     with mock.patch("{0}.next".format(builtin_module_name)) as mock_next:
-            mock_next.side_effect = Exception("SomeException")
+        mock_next.side_effect = Exception("SomeException")
 
-            with pytest.raises(LocopySplitError):
-                split_file(input_file, output_file, 2)
-            assert not Path("tests/data/mock_output_file.txt.0").exists()
-            assert not Path("tests/data/mock_output_file.txt.1").exists()
+        with pytest.raises(LocopySplitError):
+            split_file(input_file, output_file, 2)
+        assert not Path("tests/data/mock_output_file.txt.0").exists()
+        assert not Path("tests/data/mock_output_file.txt.1").exists()
 
-            with pytest.raises(LocopySplitError):
-                split_file(input_file, output_file, 3)
-            assert not Path("tests/data/mock_output_file.txt.0").exists()
-            assert not Path("tests/data/mock_output_file.txt.1").exists()
-            assert not Path("tests/data/mock_output_file.txt.2").exists()
+        with pytest.raises(LocopySplitError):
+            split_file(input_file, output_file, 3)
+        assert not Path("tests/data/mock_output_file.txt.0").exists()
+        assert not Path("tests/data/mock_output_file.txt.1").exists()
+        assert not Path("tests/data/mock_output_file.txt.2").exists()
 
 
 @mock.patch("locopy.utility.open", mock.mock_open(read_data=GOOD_CONFIG_YAML))
@@ -277,8 +275,9 @@ def test_concatenate_files_exception():
 
 def test_find_column_type():
 
-    import pandas as pd
     from decimal import Decimal
+
+    import pandas as pd
 
     # add timestamp
     input_text = pd.DataFrame.from_dict(
@@ -299,9 +298,11 @@ def test_find_column_type():
             "j": [None, "2011-01-01 12:11:02", "2022-03-02 23:59:59"],
             "k": [Decimal(3.3), Decimal(100), None],
             "l": pd.Series([1, 2, 3], dtype="category"),
+            "m": ["2022-02", "2022-03", "2020-02"],
+            "n": ["2020q1", "2021q2", "2022q3"],
         }
     )
-    output_text = {
+    output_text_snowflake = {
         "a": "int",
         "b": "varchar",
         "c": "varchar",
@@ -314,26 +315,60 @@ def test_find_column_type():
         "j": "timestamp",
         "k": "float",
         "l": "varchar",
+        "m": "varchar",
+        "n": "varchar",
     }
-    assert find_column_type(input_text) == output_text
+    output_text_redshift = {
+        "a": "int",
+        "b": "varchar",
+        "c": "varchar",
+        "d": "date",
+        "e": "float",
+        "f": "float",
+        "g": "varchar",
+        "h": "timestamp",
+        "i": "date",
+        "j": "timestamp",
+        "k": "float",
+        "l": "varchar",
+        "m": "date",
+        "n": "date",
+    }
+    assert find_column_type(input_text, "snowflake") == output_text_snowflake
+    assert find_column_type(input_text, "redshift") == output_text_redshift
 
 
 def test_get_ignoreheader_number():
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER as 1"]
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "IGNOREHEADER as 1",
+            ]
         )
         == 1
     )
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER as 2"]
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "IGNOREHEADER as 2",
+            ]
         )
         == 2
     )
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER as 99"]
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "IGNOREHEADER as 99",
+            ]
         )
         == 99
     )
@@ -359,33 +394,63 @@ def test_get_ignoreheader_number():
 
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER is 1"]
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "IGNOREHEADER is 1",
+            ]
         )
         == 1
     )
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER is 2"]
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "IGNOREHEADER is 2",
+            ]
         )
         == 2
     )
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER is 99"]
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "IGNOREHEADER is 99",
+            ]
         )
         == 99
     )
 
-    assert get_ignoreheader_number(["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS"]) == 0
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADERAS 2"]
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS"]
         )
         == 0
     )
     assert (
         get_ignoreheader_number(
-            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "SOMETHINGIGNOREHEADER AS 2"]
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "IGNOREHEADERAS 2",
+            ]
+        )
+        == 0
+    )
+    assert (
+        get_ignoreheader_number(
+            [
+                "DATEFORMAT 'auto'",
+                "COMPUPDATE ON",
+                "TRUNCATECOLUMNS",
+                "SOMETHINGIGNOREHEADER AS 2",
+            ]
         )
         == 0
     )


### PR DESCRIPTION
- Updated `find_column_type` method to only map columns types to date if they contain data with valid Snowflake date formats
- Added warehouse parameter to `find_column_type` method to differentiate column type mappings based on warehouse type (only affects dates)
- Updated test and internal calls of `find_column_type`

*Apologies for the delay, had to wait for appropriate permissions to make public github contributions