### PR TITLE
Reduced mocking in test suite, fixed minor bug

### DIFF
--- a/locopy/database.py
+++ b/locopy/database.py
@@ -225,7 +225,7 @@ class Database:
             return None
 
         if df_type == "pandas":
-            return pandas.DataFrame(fetched, columns=columns)
+            return pandas.DataFrame(fetched, columns=columns or None)
         elif df_type == "polars":
             return polars.DataFrame(fetched, schema=columns, orient="row")
 


### PR DESCRIPTION
- Reduce mocking in test suite and compared dataframes directly. 
- Fixed a bug where `pandas.DataFrame` could be called with non empty data but `columns=[]` which will error out in pandas backend.