### PR TITLE
add pyarrow support in find_column_type for pandas dataframes

### DIFF
--- a/locopy/utility.py
+++ b/locopy/utility.py
@@ -330,7 +330,7 @@ def find_column_type_pandas(dataframe: pd.DataFrame, warehouse_type: str):
         elif pa.types.is_string(pa_dtype):
             return "varchar"
         else:
-            return None
+            return "varchar"
 
     if warehouse_type.lower() not in ["snowflake", "redshift"]:
         raise ValueError(
@@ -345,13 +345,7 @@ def find_column_type_pandas(dataframe: pd.DataFrame, warehouse_type: str):
             column_type.append("varchar")
         elif isinstance(data.dtype, pd.ArrowDtype):
             datatype = check_column_type_pyarrow(data.dtype.pyarrow_dtype)
-            if datatype:
-                column_type.append(datatype)
-            else:
-                raise ValueError(
-                    "%s is not currently supported in locopy. Please raise a github issue.",
-                    column,
-                )
+            column_type.append(datatype)
         else:
             if (data.dtype in ["datetime64[ns]", "M8[ns]"]) or (
                 re.match(r"(datetime64\[ns\,\W)([a-zA-Z]+)(\])", str(data.dtype))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
   { name="Faisal Dosani", email="faisal.dosani@capitalone.com" },
 ]
 license = {text = "Apache Software License"}
-dependencies = ["boto3<=1.35.53,>=1.9.92", "PyYAML<=6.0.1,>=5.1", "pandas<=2.2.3,>=0.25.2", "numpy<=2.0.2,>=1.22.0", "polars>=0.20.0"]
+dependencies = ["boto3<=1.35.53,>=1.9.92", "PyYAML<=6.0.1,>=5.1", "pandas<=2.2.3,>=0.25.2", "numpy<=2.0.2,>=1.22.0", "polars>=0.20.0", "pyarrow>=10.0.1"]
 
 requires-python = ">=3.9.0"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
   { name="Faisal Dosani", email="faisal.dosani@capitalone.com" },
 ]
 license = {text = "Apache Software License"}
-dependencies = ["boto3<=1.35.53,>=1.9.92", "PyYAML<=6.0.1,>=5.1", "pandas<=2.2.3,>=0.25.2", "numpy<=2.0.2,>=1.22.0", "polars>=0.20.0", "pyarrow>=10.0.1"]
+dependencies = ["boto3<=1.35.53,>=1.9.92", "PyYAML<=6.0.1,>=5.1", "pandas<=2.2.3,>=1.5.0", "numpy<=2.0.2,>=1.22.0", "polars>=0.20.0", "pyarrow>=10.0.1"]
 
 requires-python = ">=3.9.0"
 classifiers = [

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from unittest import mock
 
 import locopy.utility as util
+import pyarrow as pa
 import pytest
 from locopy.errors import (
     CompressionError,
@@ -388,7 +389,48 @@ def test_find_column_type_new():
         "d": "varchar",
         "e": "boolean",
     }
+    assert find_column_type(input_text, "snowflake") == output_text_snowflake
+    assert find_column_type(input_text, "redshift") == output_text_redshift
 
+
+def test_find_column_type_pyarrow():
+    import pandas as pd
+
+    input_text = pd.DataFrame.from_dict(
+        {
+            "a": [1],
+            "b": [pd.Timestamp("2017-01-01T12+0")],
+            "c": [1.2],
+            "d": ["a"],
+            "e": [True],
+        }
+    )
+
+    input_text = input_text.astype(
+        dtype={
+            "a": "int64[pyarrow]",
+            "b": "timestamp[ns, tz=UTC][pyarrow]",
+            "c": "float64[pyarrow]",
+            "d": pd.ArrowDtype(pa.string()),
+            "e": "bool[pyarrow]",
+        }
+    )
+
+    output_text_snowflake = {
+        "a": "int",
+        "b": "timestamp",
+        "c": "float",
+        "d": "varchar",
+        "e": "boolean",
+    }
+
+    output_text_redshift = {
+        "a": "int",
+        "b": "timestamp",
+        "c": "float",
+        "d": "varchar",
+        "e": "boolean",
+    }
     assert find_column_type(input_text, "snowflake") == output_text_snowflake
     assert find_column_type(input_text, "redshift") == output_text_redshift
 


### PR DESCRIPTION
- first, check if datatype is a `pd.ArrowDtype`, if it is, call `check_column_type_pyarrow` to parse pyarrow-backed datatypes 
- else, parse as before

Fixes #282 