### PR TITLE
fix test to be compatible with pandas 1.5.0

### DIFF
--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -409,7 +409,7 @@ def test_find_column_type_pyarrow():
     input_text = input_text.astype(
         dtype={
             "a": "int64[pyarrow]",
-            "b": "timestamp[ns, tz=UTC][pyarrow]",
+            "b": pd.ArrowDtype(pa.timestamp("ns", tz="UTC")),
             "c": "float64[pyarrow]",
             "d": pd.ArrowDtype(pa.string()),
             "e": "bool[pyarrow]",


### PR DESCRIPTION
Fix datatype for test data to account for calling pyarrow specific datatype as string support which is only available in pandas 2.0 onwards, but package supports pandas 1.5.0